### PR TITLE
chore: retire unreleased Notarium prototype

### DIFF
--- a/.github/workflows/retirement.yml
+++ b/.github/workflows/retirement.yml
@@ -1,0 +1,50 @@
+name: Retirement guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Check retirement files
+        run: npm exec prettier -- --check package.json README.md CHANGELOG.md RELEASE_READINESS.md
+      - name: Verify publication guard and redirect
+        run: |
+          node --input-type=module <<'NODE'
+          import { readFile } from 'node:fs/promises';
+
+          const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+          if (packageJson.private !== true) {
+            throw new Error('package.json must remain private');
+          }
+          if (!packageJson.scripts?.prepublishOnly?.includes('@automattic/simplenote-mcp')) {
+            throw new Error('prepublishOnly must redirect to @automattic/simplenote-mcp');
+          }
+
+          for (const path of ['README.md', 'RELEASE_READINESS.md']) {
+            const content = await readFile(path, 'utf8');
+            if (!content.includes('https://github.com/Automattic/simplenote-mcp')) {
+              throw new Error(`${path} must link to the maintained implementation`);
+            }
+          }
+          NODE
+
+          if npm publish --dry-run >publish.log 2>&1; then
+            cat publish.log
+            echo "npm publication unexpectedly succeeded" >&2
+            exit 1
+          fi
+          grep -F "unreleased prototype; use @automattic/simplenote-mcp" publish.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Mark the unreleased prototype as superseded by Automattic's maintained `@automattic/simplenote-mcp` package and block accidental npm publication.

--- a/README.md
+++ b/README.md
@@ -1,165 +1,38 @@
 # MCP Notarium
 
-![MCP Notarium Header](assets/mcp-notarium-header.png)
+> [!WARNING]
+> This repository is an unreleased 2025 prototype. It is not published on npm,
+> is not release-ready, and should not be configured in an MCP client.
 
-**MCP Notarium** is a server application that acts as a bridge between Large Language Models (LLMs) and the [Simplenote](https://simplenote.com/) note-taking service. It exposes a set of tools compliant with the Model Context Protocol (MCP), enabling LLMs to read, write, search, and manage a user's Simplenote notes.
+Use Automattic's maintained Simplenote integration instead:
 
-This project is designed to be run by individual users for their own Simplenote account, providing secure and controlled access to their notes via an AI agent or similar MCP-compatible client.
-
-## Features
-
-- **MCP-Compliant Tools:** Exposes `list`, `get`, `save`, and `manage` tools for comprehensive note interaction.
-- **Simplenote Integration:** Connects directly to your Simplenote account using your credentials.
-- **Local Caching:** Utilizes a local SQLite database to cache notes for fast read access and offline capabilities (syncs when online).
-- **Optional Database Encryption:** Secure your local note cache with an encryption key using SQLCipher.
-- **Text Patching:** Efficiently update notes using line-based text patches for the `save` tool, minimizing data transfer.
-- **Configuration via Environment Variables:** Easy setup using standard environment variables or a `.env` file.
-- **Background Sync:** Periodically syncs with the Simperium backend (Simplenote's sync provider) to keep the local cache up-to-date.
-
-## Core Architecture
-
-MCP Notarium consists of several key components:
-
-- **MCP Server Core:** Listens for JSON-RPC 2.0 requests over `stdio` and dispatches them to the appropriate tool handlers.
-- **Tool Handlers:** Implement the logic for `list`, `get`, `save`, and `manage` operations.
-- **Local Cache Module:** Manages an SQLite database (optionally encrypted with SQLCipher) for storing notes locally.
-- **Backend API Client:** Interacts with the Simperium API for authentication and direct note operations.
-- **Backend Sync Service:** Runs in the background to synchronize local notes with the Simperium backend.
-
-## Prerequisites
-
-- **Node.js:** Version 20.19 or later in the 20.x line, version 22.13 or later in the 22.x line, or version 24 and later is required (as specified in `package.json` engines).
-- **Simplenote Account:** You need an active Simplenote account.
-
-## Installation and Usage
-
-### Using `npx` (Recommended for Quick Use)
-
-The easiest way to run MCP Notarium is using `npx`. This ensures you are running the latest version without needing a local installation.
+- Repository: <https://github.com/Automattic/simplenote-mcp>
+- npm: <https://www.npmjs.com/package/@automattic/simplenote-mcp>
 
 ```bash
-npx mcp-notarium
+npx -y @automattic/simplenote-mcp setup
 ```
 
-When run via `npx`, MCP Notarium will start, attempt to authenticate with Simplenote (using configured environment variables), and then listen for MCP requests on `stdio`.
-
-### Local Installation (for Development or Persistent Use)
-
-1.  **Clone the repository (if not already done for development):**
-
-    ```bash
-    git clone <repository-url>
-    cd mcp-notarium
-    ```
-
-2.  **Install dependencies:**
-
-    ```bash
-    npm install
-    ```
-
-    If you plan to use database encryption, ensure that `better-sqlite3-sqlcipher` can be built on your system. This might require build tools like `python`, `make`, and a C++ compiler.
-
-3.  **Build the project:**
-
-    ```bash
-    npm run build
-    ```
-
-4.  **Run the server:**
-    ```bash
-    npm start
-    ```
-
-## Configuration
-
-MCP Notarium is configured primarily through environment variables. You can set these in your shell, or create a `.env` file in the root of the project directory (if running from a local clone) or in the directory where you execute `npx mcp-notarium`.
-
-**Example `.env` file:**
-
-```env
-SIMPLENOTE_USERNAME="your_simplenote_email@example.com"
-SIMPLENOTE_PASSWORD="your_simplenote_password"
-
-# Optional: For local cache encryption (highly recommended)
-# DB_ENCRYPTION_KEY="your-strong-unique-passphrase-for-db-encryption"
-
-# Optional: Adjust sync interval (seconds)
-# SYNC_INTERVAL_SECONDS=300
-
-# Optional: API timeout (seconds)
-# API_TIMEOUT_SECONDS=30
-
-# Optional: Log level (trace, debug, info, warn, error, fatal)
-# LOG_LEVEL="info"
-
-# Optional: Log to a file
-# LOG_FILE_PATH="./notarium.log"
-```
-
-### Key Environment Variables:
-
-- `SIMPLENOTE_USERNAME` (**Required**): Your Simplenote email address.
-- `SIMPLENOTE_PASSWORD` (**Required**): Your Simplenote password.
-- `DB_ENCRYPTION_KEY` (Optional, Recommended): A strong passphrase to encrypt the local SQLite cache. If not provided, the cache will be unencrypted.
-- `DB_ENCRYPTION_KDF_ITERATIONS` (Optional, Default: `310000`): Number of PBKDF2 iterations for deriving the database encryption key. Higher is more secure but slower to open.
-- `SYNC_INTERVAL_SECONDS` (Optional, Default: `300`): How often (in seconds) the background sync service will attempt to pull changes from Simplenote. Minimum: `60`.
-- `API_TIMEOUT_SECONDS` (Optional, Default: `30`): Timeout in seconds for API calls to the Simplenote (Simperium) backend. Minimum: `5`.
-- `LOG_LEVEL` (Optional, Default: `INFO`): Sets the logging verbosity. Valid levels: `trace`, `debug`, `info`, `warn`, `error`, `fatal`.
-- `LOG_FILE_PATH` (Optional): If set, logs will also be written to this file path in addition to `stdout`.
-
-### Printing Configuration
-
-To see a list of all configuration variables, their purpose, and their current effective values (with secrets masked), you can run:
+Then register it with an MCP client:
 
 ```bash
-# If using npx
-npx mcp-notarium --print-config-vars
-
-# If installed locally
-npm start -- --print-config-vars
-# or if linked globally/via bin
-mcp-notarium --print-config-vars
+codex mcp add simplenote -- npx -y @automattic/simplenote-mcp
 ```
 
-## Usage with MCP Clients
+The maintained implementation supports the current Simplenote authentication
+flow, the macOS Simplenote data store, current MCP SDK behavior, and opt-in
+write tools.
 
-MCP Notarium communicates over `stdio` using JSON-RPC 2.0. An MCP client (like an AI agent environment) can start MCP Notarium as a child process and communicate with it by writing JSON-RPC requests to its `stdin` and reading JSON-RPC responses from its `stdout`.
+## Prototype Status
 
-The service name is `mcp_notarium`.
+MCP Notarium was started in May 2025 as an experimental Simplenote-to-MCP
+bridge. Version `1.0.0` was present in the initial package scaffold, not created
+by a release process. The repository has no tags, GitHub Releases, changelog
+history, or published `mcp-notarium` package.
 
-### Available Tools:
-
-- **`mcp_notarium.list`**: Lists notes with filtering and pagination options.
-- **`mcp_notarium.get`**: Retrieves a specific note by its ID, optionally a specific version or a range of lines.
-- **`mcp_notarium.save`**: Creates a new note or updates an existing one. Supports full text content or line-based patches (`txt_patch`).
-- **`mcp_notarium.manage`**: Performs management actions:
-  - `get_stats`: Retrieves server and sync statistics.
-  - `reset_cache`: Deletes the local cache, forcing a full resync.
-  - `trash`: Moves a note to the trash.
-  - `untrash`: Restores a note from the trash.
-  - `delete_permanently`: Deletes a note permanently from the local cache (V1: does not hard-delete from server).
-
-(Refer to `docs/spec.md` for detailed tool schemas and parameters.)
-
-## Security Considerations
-
-- **Credentials**: Your `SIMPLENOTE_USERNAME` and `SIMPLENOTE_PASSWORD` are sensitive. Ensure they are protected, especially if you use a `.env` file (e.g., by adding `.env` to your global `.gitignore`).
-- **Database Encryption Key**: If you use `DB_ENCRYPTION_KEY`, choose a strong, unique passphrase. This key encrypts your notes stored locally. If you lose this key, you will lose access to the local cache (though your notes remain on Simplenote's servers).
-- **API Key**: The Simperium App ID and API Key used by this application are typically considered public client identifiers for the Simplenote application on Simperium and are hardcoded as per common client practices.
-
-## Known Limitations (V1)
-
-- **Hard Delete Detection:** Notes hard-deleted from Simplenote by _other_ clients might not be immediately removed from the local cache (they will be marked as `sync_deleted` if a fetch for their specific version fails, or on full resync if the index no longer contains them). The `delete_permanently` manage action is local-only in V1.
-- **Search Typo-Tolerance:** Search via the `q` parameter relies on SQLite FTS5, which has good prefix matching but not advanced typo correction (e.g., Levenshtein distance).
-- **Schema Migrations:** No automated, non-destructive schema migrations for the local SQLite database are implemented. Significant schema changes would require a cache reset.
-
-## Future Considerations
-
-- Advanced fuzzy search integration.
-- Periodic full cache reconciliation for robust hard delete detection.
-- Automated, non-destructive SQLite schema migrations.
-- Support for other note-taking backends.
+The prototype is intentionally blocked from npm publication with
+`"private": true` and a `prepublishOnly` guard. See
+[RELEASE_READINESS.md](./RELEASE_READINESS.md) for the audit evidence.
 
 ## License
 

--- a/RELEASE_READINESS.md
+++ b/RELEASE_READINESS.md
@@ -1,0 +1,54 @@
+# Release Readiness
+
+Audit date: June 11, 2026
+
+## Decision
+
+Do not publish `mcp-notarium@1.0.0`.
+
+This repository is an unreleased prototype that has been superseded by
+Automattic's maintained Simplenote MCP implementation:
+
+- <https://github.com/Automattic/simplenote-mcp>
+- <https://www.npmjs.com/package/@automattic/simplenote-mcp>
+
+## Evidence
+
+- `1.0.0` has been present since the initial package scaffold on May 18, 2025;
+  it was not introduced by a release commit.
+- The repository has no tags, GitHub Releases, or historical changelog.
+- The public npm registry returns `404` for `mcp-notarium`.
+- The latest human-authored product commit is from May 20, 2025. The June 2026
+  commits only refresh dependencies.
+- `npm test` fails 48 of 116 tests on current `main`.
+- `npm run lint:check-format` reports 21 unformatted files.
+- `npm run lint` reports 50 warnings.
+- The packed executable has no shebang, while `package.json` exposes it as an
+  npm binary.
+- The README advertised `npx mcp-notarium` despite no published package.
+- The documented password-based Simplenote flow is obsolete. The maintained
+  implementation uses Simplenote's current login-code flow or the local macOS
+  Simplenote store.
+- The prototype contains production placeholders and incomplete cache/schema
+  checks.
+- GitHub has no open issues or pull requests, and current `main` has no
+  repository CI workflow covering tests, lint, build, or package execution.
+
+## Reproduction
+
+```bash
+git checkout main
+npm ci
+npm run lint
+npm run lint:check-format
+npm test
+npm run build
+npm pack --dry-run
+```
+
+## Publication Guard
+
+`package.json` is marked private and includes a `prepublishOnly` failure. Remove
+both only after an explicit decision to build and maintain a distinct product,
+followed by a new implementation, live Simplenote proof, current MCP client
+proof, green CI, and a fresh release review.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "mcp-notarium",
   "version": "1.0.0",
-  "description": "MCP Notarium: A bridge between LLMs and Simplenote.",
+  "private": true,
+  "description": "Unreleased Simplenote MCP prototype. Use @automattic/simplenote-mcp.",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
@@ -14,7 +15,8 @@
     "format": "prettier --write \"src/**/*.ts\" \"docs/**/*.md\" \"*.{js,json,md,cjs,mjs}\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "print-config-vars": "node dist/index.js --print-config-vars"
+    "print-config-vars": "node dist/index.js --print-config-vars",
+    "prepublishOnly": "node -e \"throw new Error('mcp-notarium is an unreleased prototype; use @automattic/simplenote-mcp')\""
   },
   "bin": {
     "mcp-notarium": "dist/index.js"
@@ -25,8 +27,16 @@
     "llm",
     "notetaking"
   ],
-  "author": "",
+  "author": "Peter Steinberger",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/steipete/notarium-mcp.git"
+  },
+  "homepage": "https://github.com/steipete/notarium-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/steipete/notarium-mcp/issues"
+  },
   "dependencies": {
     "axios": "^1.17.0",
     "dotenv": "^16.6.1",


### PR DESCRIPTION
## Summary

- mark `mcp-notarium` as a private, unreleased prototype
- block accidental npm publication with `prepublishOnly`
- redirect users to Automattic's maintained implementation: https://github.com/Automattic/simplenote-mcp
- document the release-readiness audit and historical failure evidence
- add focused CI covering the retirement guard instead of asserting the abandoned implementation is healthy

## Verification

- `npm exec prettier -- --check package.json README.md CHANGELOG.md RELEASE_READINESS.md .github/workflows/retirement.yml`
- publication guard assertions for `package.json`, `README.md`, and `RELEASE_READINESS.md`
- `npm publish --dry-run` fails with the intended redirect message
- Codex autoreview: clean, no accepted/actionable findings

## Scope

No npm publication, version bump, tag, or GitHub Release. The legacy application test failures are documented in `RELEASE_READINESS.md`; this PR retires the prototype rather than representing it as release-ready.
